### PR TITLE
Add sanitization code

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/StatsdClient.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/StatsdClient.java
@@ -1,0 +1,164 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 jxpearce.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.githubautostatus;
+
+import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.StatsDClient;
+import com.timgroup.statsd.StatsDClientException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.logging.Logger;
+
+/**
+ * Wraps regular UDP based Statd client with concurrent hostname refreshing logic.
+ * 
+ * @author Tom Hadlaw (thomas.hadlaw@hootsuite.com)
+ */
+public class StatsdClient implements StatsdWrapper {
+    private final int CLIENT_TTL = 300;
+    private static final Logger LOGGER = Logger.getLogger(StatsdClient.class.getName());
+
+    private static StatsDClient client;
+    private String hostname = "";
+    private String prefix = "";
+    private int port = 8125;
+    private ReentrantReadWriteLock lock;
+
+    /**
+     * newClient attempts to create a new statsd client instance, if succesful then
+     * the active client is safely swapped out.
+     * 
+     * @throws StatsDClientException
+     */
+    private void newClient() throws StatsDClientException {
+        Lock wl = lock.writeLock();
+        StatsDClient newClient = null;
+        try {
+            newClient = new NonBlockingStatsDClient(prefix, hostname, port);
+        } catch (StatsDClientException e) {
+            LOGGER.warning("Could not refresh client, will continue to use old instance");
+
+            if (client == null) {
+                throw e;
+            }
+            return;
+        }
+
+        // only aquire write lock if hostname resolution succeeded.
+        wl.lock();
+        try {
+            if (client != null) {
+                // this will flush remaining messages out of queue.
+                client.stop();
+            }
+            client = newClient;
+        } catch (Exception e) {
+            LOGGER.warning("Could not refresh client, will continue to use old instance");
+            if (client == null) {
+                throw e;
+            }
+        } finally {
+            wl.unlock();
+        }
+    }
+
+    /**
+     * Constructs a new StatsdClient.
+     * 
+     * @param prefix   Statsd prefix
+     * @param hostname Statsd collector hostname (default localhost)
+     * @param port     Statsd collector listener port (default 8125)
+     */
+    public StatsdClient(String prefix, String hostname, int port) throws StatsDClientException {
+        this.hostname = hostname;
+        this.prefix = prefix;
+        this.port = port;
+
+        this.lock = new ReentrantReadWriteLock();
+        ScheduledExecutorService exec = Executors.newSingleThreadScheduledExecutor();
+
+        exec.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                System.out.println("Refreshing Client");
+                newClient();
+            }
+        }, CLIENT_TTL, CLIENT_TTL, TimeUnit.SECONDS);
+
+        this.newClient();
+    }
+
+    /**
+     * Execute Invokes runnable surrounded in the objects readlock.
+     * 
+     * @param l Runnable to be invoked.
+     */
+    private void execLocked(Runnable l) {
+        Lock rl = lock.readLock();
+        rl.lock();
+        try {
+            l.run();
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            rl.unlock();
+        }
+    }
+
+    /**
+     * Runs a Statsd increment in a safe way.
+     * 
+     * @param key    the bucket key
+     * @param amount amount to increment
+     */
+    @Override
+    public void increment(String key, int amount) {
+        execLocked(new Runnable() {
+            @Override
+            public void run() {
+                System.out.println("ok ... doing increment");
+                client.increment(key, amount);
+            }
+        });
+    }
+
+    /**
+     * Run a Statsd timer state in a safe way.
+     * 
+     * @param key the bucket key
+     * @param duration the duration
+     */
+    @Override
+    public void time(String key, long duration) {
+        execLocked(new Runnable() {
+            @Override
+            public void run() {
+                client.time(key, duration);
+            }
+        });
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
@@ -137,6 +137,12 @@ public class StatsdNotifier implements BuildNotifier {
         return key.replaceAll("\\s+", "_").replaceAll("/", ".").replaceAll("[^a-zA-Z_\\-0-9\\.]", "");
     }
 
+    /**
+     * Collapses empty buckets into a single period.
+     * 
+     * @param key key to sanitize
+     * @return sanitized key
+     */
     private String collapseEmptyBuckets(String key) {
         return key.replaceAll("\\.{2,}", ".");
     }

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
@@ -65,7 +65,10 @@ public class StatsdNotifier implements BuildNotifier {
      * @return string of path up to branch bucket
      */
     private String getBranchPath() {
-        return String.format("pipeline.%s.%s.branch.%s", config.getRepoOwner(), config.getRepoName(), config.getBranchName());
+        String sanitizedFolderPath = sanitizeAll(config.getRepoOwner());
+        String sanitizedJobName = sanitizeAll(config.getRepoName());
+        String sanitizedBranchName = sanitizeAll(config.getBranchName());
+        return String.format("pipeline.%s.%s.branch.%s", sanitizedFolderPath, sanitizedJobName, sanitizedBranchName);
     }
 
     /**
@@ -76,7 +79,7 @@ public class StatsdNotifier implements BuildNotifier {
      * @param buildState the reported state
      */
     public void notifyBuildState(String jobName, String nodeName, BuildState buildState) {
-        String fqp = String.format("%s.stage.%s.status.%s", getBranchPath(), nodeName, buildState);  
+        String fqp = String.format("%s.stage.%s.status.%s", getBranchPath(), sanitizeAll(nodeName), buildState);  
         client.increment(fqp, 1);
     }
 
@@ -87,7 +90,7 @@ public class StatsdNotifier implements BuildNotifier {
      * @param nodeName the stage of the status on which to report on
      */
     public void notifyBuildStageStatus(String jobName, String nodeName, BuildState buildState, long nodeDuration) {
-        String fqp = String.format("%s.stage.%s.duration", getBranchPath(), nodeName);
+        String fqp = String.format("%s.stage.%s.duration", getBranchPath(), sanitizeAll(nodeName));
         client.time(fqp, nodeDuration);
     }
 
@@ -115,7 +118,38 @@ public class StatsdNotifier implements BuildNotifier {
      * @param nodeName the stage of the status on which to report on
      */
     public void sendNonStageError(String jobName, String nodeName) {
-        String fqp = String.format("%s.stage.%s.none_stage_error", getBranchPath(), nodeName);  
+        String fqp = String.format("%s.stage.%s.none_stage_error", getBranchPath(), sanitizeAll(nodeName));  
         client.increment(fqp, 1);
+    }
+
+    /**
+     * Does the same sanitization as Statsd would do if sanitization is on.
+     * See: https://github.com/statsd/statsd/blob/master/stats.js#L168
+     * 
+     * @param key key to sanitize
+     * @return santized key
+     */
+    private String statsdSanitizeKey(String key) {
+        return key.replaceAll("\\s+", "_").replaceAll("/", "-").replaceAll("[^a-zA-Z_\\-0-9\\.]", "");
+    }
+
+    /**
+     * Does Jenkins specific key sanitization.
+     * 
+     * @param key key to sanitize
+     * @return sanitized key
+     */
+    private String sanitizeKey(String key) {
+        return key.replaceAll("\\.", "");
+    }
+
+    /**
+     * Applies all sanitizations to a key
+     * 
+     * @param key key to sanitize
+     * @return sanitized key
+     */
+    private String sanitizeAll(String key) {
+        return sanitizeKey(statsdSanitizeKey(key));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
@@ -130,7 +130,7 @@ public class StatsdNotifier implements BuildNotifier {
      * @return santized key
      */
     private String statsdSanitizeKey(String key) {
-        return key.replaceAll("\\s+", "_").replaceAll("/", "-").replaceAll("[^a-zA-Z_\\-0-9\\.]", "");
+        return key.replaceAll("\\s+", "_").replaceAll("/", ".").replaceAll("[^a-zA-Z_\\-0-9\\.]", "");
     }
 
     /**
@@ -144,12 +144,12 @@ public class StatsdNotifier implements BuildNotifier {
     }
 
     /**
-     * Applies all sanitizations to a key
+     * Applies all sanitizations to a key, folders are expanded into seperate statsd buckets
      * 
      * @param key key to sanitize
      * @return sanitized key
      */
     private String sanitizeAll(String key) {
-        return sanitizeKey(statsdSanitizeKey(key));
+        return statsdSanitizeKey(sanitizeKey(key));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
@@ -24,6 +24,7 @@
 package org.jenkinsci.plugins.githubautostatus.notifiers;
 
 import org.jenkinsci.plugins.githubautostatus.StatsdWrapper;
+import org.jenkinsci.plugins.githubautostatus.StatsdClient;
 import org.jenkinsci.plugins.githubautostatus.StatsdNotifierConfig;
 
 import java.util.logging.Logger;
@@ -36,6 +37,9 @@ public class StatsdNotifier implements BuildNotifier {
     private StatsdWrapper client;
     protected StatsdNotifierConfig config;
     private static final Logger LOGGER = Logger.getLogger(StatsdWrapper.class.getName());
+    public StatsdNotifier(StatsdWrapper client) {
+        this.client = client;
+    }
 
     public StatsdNotifier(StatsdNotifierConfig config) {
         this.config = config;
@@ -47,7 +51,7 @@ public class StatsdNotifier implements BuildNotifier {
                 LOGGER.warning("Could not parse port '" + config.getStatsdPort() + "', using 8125 (default)");
             }
         }
-        client = new StatsdWrapper(config.getStatsdBucket(), config.getStatsdHost(), port);
+        client = new StatsdClient(config.getStatsdBucket(), config.getStatsdHost(), port);
     }
 
     /**
@@ -64,7 +68,7 @@ public class StatsdNotifier implements BuildNotifier {
      * 
      * @return string of path up to branch bucket
      */
-    private String getBranchPath() {
+    public String getBranchPath() {
         String sanitizedFolderPath = sanitizeAll(config.getRepoOwner());
         String sanitizedJobName = sanitizeAll(config.getRepoName());
         String sanitizedBranchName = sanitizeAll(config.getBranchName());
@@ -149,7 +153,7 @@ public class StatsdNotifier implements BuildNotifier {
      * @param key key to sanitize
      * @return sanitized key
      */
-    private String sanitizeAll(String key) {
+    public String sanitizeAll(String key) {
         return statsdSanitizeKey(sanitizeKey(key));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
@@ -137,6 +137,10 @@ public class StatsdNotifier implements BuildNotifier {
         return key.replaceAll("\\s+", "_").replaceAll("/", ".").replaceAll("[^a-zA-Z_\\-0-9\\.]", "");
     }
 
+    private String collapseEmptyBuckets(String key) {
+        return key.replaceAll("\\.{2,}", ".");
+    }
+
     /**
      * Does Jenkins specific key sanitization.
      * 
@@ -156,6 +160,6 @@ public class StatsdNotifier implements BuildNotifier {
      * @return sanitized key
      */
     public String sanitizeAll(String key) {
-        return statsdSanitizeKey(sanitizeKey(key));
+        return collapseEmptyBuckets(statsdSanitizeKey(sanitizeKey(key)));
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifier.java
@@ -148,7 +148,9 @@ public class StatsdNotifier implements BuildNotifier {
     }
 
     /**
-     * Applies all sanitizations to a key, folders are expanded into seperate statsd buckets
+     * Applies all sanitizations to a key, folders are expanded into seperate statsd buckets.
+     * It firest applies bucket sanitization (removing periods to prevent them being interprested as 
+     * seperate buckets). It the applies the statsd bucket key sanitization.
      * 
      * @param key key to sanitize
      * @return sanitized key

--- a/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
@@ -1,0 +1,99 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 jxpearce.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.githubautostatus.notifiers;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.Base64;
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.util.EntityUtils;
+//import org.jenkinsci.plugins.githubautostatus.StatsdNotifierConfig;
+import org.jenkinsci.plugins.githubautostatus.StatsdNotifierConfig;
+import org.jenkinsci.plugins.githubautostatus.StatsdWrapper;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ *
+ * @author tom hadlaw
+ */
+public class StatsdNotifierTest {
+
+    private org.jenkinsci.plugins.githubautostatus.StatsdNotifierConfig config;
+    private StatsdWrapper mockClient;
+    private StatsdNotifier notifier;
+
+    public StatsdNotifierTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws IOException {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() throws MalformedURLException, IOException {
+        config = mock(StatsdNotifierConfig.class);
+        when(config.getBranchName()).thenReturn("master");
+        when(config.getRepoOwner()).thenReturn("folder0 / folder1 / folder.2/ folder  3");
+        when(config.getRepoName()).thenReturn("this .   is ... the ... reponame");
+
+        mockClient = mock(StatsdWrapper.class);
+        notifier = new StatsdNotifier(mockClient);
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testSanitizeAll() throws IOException {
+        String out = notifier.sanitizeAll(config.getBranchName());
+        assertEquals(out, "master");
+        out = notifier.sanitizeAll(config.getRepoName());
+        assertEquals(out, "this_is_the_reponame");
+        out = notifier.sanitizeAll(config.getRepoOwner());
+        assertEquals("folder0_._folder1_._folder2._folder_3", out);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
@@ -35,7 +35,6 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
-//import org.jenkinsci.plugins.githubautostatus.StatsdNotifierConfig;
 import org.jenkinsci.plugins.githubautostatus.StatsdNotifierConfig;
 import org.jenkinsci.plugins.githubautostatus.StatsdWrapper;
 import org.junit.After;

--- a/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
@@ -60,7 +60,7 @@ public class StatsdNotifierTest {
     @Before
     public void setUp() throws MalformedURLException, IOException {
         config = mock(StatsdNotifierConfig.class);
-        when(config.getBranchName()).thenReturn("master");
+        when(config.getBranchName()).thenReturn("a///////...////....b");
         when(config.getRepoOwner()).thenReturn("folder0 / folder1 /     folder.2/ folder  3");
         when(config.getRepoName()).thenReturn("this .   is ... the ... reponame");
 
@@ -75,7 +75,7 @@ public class StatsdNotifierTest {
     @Test
     public void testSanitizeAll() throws IOException {
         String out = notifier.sanitizeAll(config.getBranchName());
-        assertEquals(out, "master");
+        assertEquals("a.b", out);
         out = notifier.sanitizeAll(config.getRepoName());
         assertEquals(out, "this_is_the_reponame");
         out = notifier.sanitizeAll(config.getRepoOwner());

--- a/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
@@ -61,7 +61,7 @@ public class StatsdNotifierTest {
     public void setUp() throws MalformedURLException, IOException {
         config = mock(StatsdNotifierConfig.class);
         when(config.getBranchName()).thenReturn("master");
-        when(config.getRepoOwner()).thenReturn("folder0 / folder1 / folder.2/ folder  3");
+        when(config.getRepoOwner()).thenReturn("folder0 / folder1 /     folder.2/ folder  3");
         when(config.getRepoName()).thenReturn("this .   is ... the ... reponame");
 
         mockClient = mock(StatsdWrapper.class);
@@ -79,6 +79,8 @@ public class StatsdNotifierTest {
         out = notifier.sanitizeAll(config.getRepoName());
         assertEquals(out, "this_is_the_reponame");
         out = notifier.sanitizeAll(config.getRepoOwner());
+        // path sanitization should come first, leading and following whitespaces should
+        // be turned into a single underscore.
         assertEquals("folder0_._folder1_._folder2._folder_3", out);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
@@ -23,18 +23,8 @@
  */
 package org.jenkinsci.plugins.githubautostatus.notifiers;
 
-import com.cloudbees.plugins.credentials.CredentialsScope;
-import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
-import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.util.Base64;
-import org.apache.http.HttpEntity;
-import org.apache.http.StatusLine;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.util.EntityUtils;
 import org.jenkinsci.plugins.githubautostatus.StatsdNotifierConfig;
 import org.jenkinsci.plugins.githubautostatus.StatsdWrapper;
 import org.junit.After;
@@ -43,12 +33,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import org.mockito.invocation.InvocationOnMock;
 
 /**
  *

--- a/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
+++ b/src/test/java/org/jenkinsci/plugins/githubautostatus/notifiers/StatsdNotifierTest.java
@@ -60,7 +60,7 @@ public class StatsdNotifierTest {
     @Before
     public void setUp() throws MalformedURLException, IOException {
         config = mock(StatsdNotifierConfig.class);
-        when(config.getBranchName()).thenReturn("a///////...////....b");
+        when(config.getBranchName()).thenReturn("a////<>\\|;:%/!@#$%^&*()+=//...////....b");
         when(config.getRepoOwner()).thenReturn("folder0 / folder1 /     folder.2/ folder  3");
         when(config.getRepoName()).thenReturn("this .   is ... the ... reponame");
 


### PR DESCRIPTION
Adding methods to better sanitize bucket keys, without relying on Statsd sanitization.

The rules are:

* Periods are removed.
* Contiguous whitespaces become a single underscore.
* Paths (slashes) become bucket keys. Replace all slashes with periods.
* key prefixes starting with alphanumeric chars followed by underscore and a number and finally a period get removed (this is just mimicking the statsd behavior).
* Finally all empty buckets are collapsed.
 
Also I refactored some classes to allow for easier unit testing